### PR TITLE
Fix: Automatically Add TrackSearchBox When Last Box is Deleted

### DIFF
--- a/react-client/src/layouts/SearchTrackBox.tsx
+++ b/react-client/src/layouts/SearchTrackBox.tsx
@@ -17,7 +17,7 @@ type ImageSize = 100 | 80 | 70;
 interface Prob {
   selectedTrack:SelectedTrack
   selectTrack :(id: number, selectedTrack: TrackWithArtistResponse) => void;
-  addSelectBox:(id:number)=> void
+  changeBoxActivateToTrue:(id:number)=> void
   deleteSelectBox:(id:number) => void
   deleteTrack:(id:number) => void
 }
@@ -25,7 +25,7 @@ interface Prob {
 export default function SearchTrackBox({
   selectedTrack,
   selectTrack,
-  addSelectBox,
+  changeBoxActivateToTrue,
   deleteSelectBox,
   deleteTrack,
 }:Prob) {
@@ -173,7 +173,7 @@ export default function SearchTrackBox({
         className={`bg-white ${width} flex items-center rounded-xl bg-[#0b57d11c] hover:bg-gray-400 responsive-text text-gray-500 px-10 ${height}`}
         role='button'
         tabIndex={0}
-        onClick={(e) => { e.stopPropagation(); addSelectBox(selectedTrack.id); }}
+        onClick={(e) => { e.stopPropagation(); changeBoxActivateToTrue(selectedTrack.id); }}
         >
           + 추가
         </div>

--- a/react-client/src/layouts/SearchTrackBoxContainer.tsx
+++ b/react-client/src/layouts/SearchTrackBoxContainer.tsx
@@ -8,19 +8,13 @@ import SearchTrackBox from './SearchTrackBox';
 interface Prob{
   setSelectedTracks: Updater<SelectedTrack[]>;
   calculateBoxWidth: ()=>string,
-  selectedTrackLength:number
   selectedTrack:SelectedTrack
-  additionalBoxRenderCondition:boolean
-  index:number
 }
 
 export function SearchTrackBoxContainer({
   setSelectedTracks,
   selectedTrack,
   calculateBoxWidth,
-  additionalBoxRenderCondition,
-  selectedTrackLength,
-  index,
 }:Prob) {
   const colorArray = Object.values(Color);
   function selectTrack(id: number, selectedTrack: TrackWithArtistResponse) {
@@ -46,53 +40,40 @@ export function SearchTrackBoxContainer({
     });
   }
 
-  function addSelectBox(id:number) {
+  function changeBoxActivateToTrue(id:number) {
     setSelectedTracks((draft) => {
-      draft.push({
-        id, activate: true, color: colorArray[id], track: null,
+      draft.forEach((item) => {
+        if (item.id === id) {
+          item.activate = true;
+        }
       });
     });
   }
 
   function deleteSelectBox(id: number) {
     setSelectedTracks((draft) => {
-      // 해당 id를 가진 박스를 배열에서 삭제
       const index = draft.findIndex((box) => box.id === id);
       if (index !== -1) {
-        draft.splice(index, 1); // 배열에서 해당 인덱스의 요소를 제거
+        draft.splice(index, 1); // 해당 요소 제거
+
+        // 모든 요소의 id 재할당
+        draft.forEach((box, i) => {
+          box.id = i;
+          box.color = colorArray[i];
+        });
       }
     });
   }
 
   return (
-    <>
-      <div style={{ width: calculateBoxWidth() }}>
-        <SearchTrackBox
-          selectedTrack={selectedTrack}
-          selectTrack={selectTrack}
-          addSelectBox={addSelectBox}
-          deleteSelectBox={deleteSelectBox}
-          deleteTrack={deleteTrack}
-        />
-      </div>
-
-      {/* 마지막 인덱스에서 추가 박스 렌더링 */}
-      { (index === selectedTrackLength - 1 && additionalBoxRenderCondition) && (
-      <div style={{ width: calculateBoxWidth() }}>
-        <SearchTrackBox
-          selectedTrack={{
-            id: selectedTrackLength,
-            activate: false,
-            color: colorArray[selectedTrackLength],
-            track: null,
-          }}
-          selectTrack={selectTrack}
-          addSelectBox={addSelectBox}
-          deleteSelectBox={deleteSelectBox}
-          deleteTrack={deleteTrack}
-        />
-      </div>
-      )}
-    </>
+    <div style={{ width: calculateBoxWidth() }}>
+      <SearchTrackBox
+        selectedTrack={selectedTrack}
+        selectTrack={selectTrack}
+        changeBoxActivateToTrue={changeBoxActivateToTrue}
+        deleteSelectBox={deleteSelectBox}
+        deleteTrack={deleteTrack}
+      />
+    </div>
   );
 }

--- a/react-client/src/pages/ExplorePage.tsx
+++ b/react-client/src/pages/ExplorePage.tsx
@@ -47,7 +47,7 @@ export default function ExplorePage() {
     navigate(`?${queryParams.toString()}`, { replace: true });
   }
 
-  async function checkURL() {
+  async function syncSelectedTracksWithURL() {
     try {
       const queryParams = new URLSearchParams(location.search);
       const selectedTracksParam = queryParams.get('selectedTracks');
@@ -68,7 +68,7 @@ export default function ExplorePage() {
   }
 
   useEffect(() => {
-    checkURL();
+    syncSelectedTracksWithURL();
   }, []);
 
   useEffect(() => {

--- a/react-client/src/sections/ExploreSection1.tsx
+++ b/react-client/src/sections/ExploreSection1.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable consistent-return */
+/* eslint-disable no-param-reassign */
 
 import { SearchTrackBoxContainer } from '@layouts/SearchTrackBoxContainer';
-import { SelectedTrack } from '@pages/ExplorePage';
+import { Color, SelectedTrack } from '@pages/ExplorePage';
 
 import { useEffect, useRef, useState } from 'react';
 import { Updater } from 'use-immer';
@@ -15,10 +16,8 @@ export default function ExploreSection1({
   setSelectedTracks,
   selectedTracks,
 }:Prob) {
-  const additionalBoxRenderCondition = !!(
-    selectedTracks[selectedTracks.length - 1]?.track && selectedTracks.length < 6);
-  const totalBoxes = selectedTracks.length
-    + ((additionalBoxRenderCondition || selectedTracks.length === 0) ? 1 : 0);
+  const colorArray = Object.values(Color);
+  const totalBoxes = selectedTracks.length;
   const [containerWidth, setContainerWidth] = useState<number>(0);
   const containerRef = useRef<HTMLInputElement>(null);
 
@@ -32,6 +31,27 @@ export default function ExploreSection1({
     }
     return `${(containerWidth - gap * 8) / 3}px`;
   }
+
+  useEffect(() => {
+    if (selectedTracks.length === 1) {
+      setSelectedTracks((draft) => {
+        draft.forEach((box) => { box.activate = true; });
+      });
+    }
+    const additionalBoxRenderCondition = !!(
+      selectedTracks[selectedTracks.length - 1]?.track && selectedTracks.length < 6);
+
+    if (additionalBoxRenderCondition) {
+      setSelectedTracks((draft) => {
+        draft.push({
+          id: draft.length,
+          activate: false,
+          color: colorArray[draft.length],
+          track: null,
+        });
+      });
+    }
+  }, [selectedTracks]);
 
   // 브라우저 리사이즈 감지
   useEffect(() => {
@@ -58,12 +78,9 @@ export default function ExploreSection1({
       {selectedTracks.map((selectedTrack, index) => (
         <SearchTrackBoxContainer
           key={index}
-          index={index}
-          selectedTrackLength={selectedTracks.length}
           setSelectedTracks={setSelectedTracks}
           selectedTrack={selectedTrack}
-          calculateBoxWidth={calculateBoxWidth}
-          additionalBoxRenderCondition={additionalBoxRenderCondition} />
+          calculateBoxWidth={calculateBoxWidth} />
       ))}
 
     </section>


### PR DESCRIPTION
- [추가박스 렌더로직 @sections/ExploreSection1 의 useEffect로 이동](https://github.com/woong8249/trackVStrack/compare/main...13-bug-fix-automatically-add-tracksearchbox-when-last-box-is-deleted#diff-b3234b762871ccb99e05a91d86fa5a84400c4fda9228dabbbb02e961b6d9e214)

- 함수명 변경
  - [react-client/src/pages/ExplorePage.tsx](https://github.com/woong8249/trackVStrack/compare/main...13-bug-fix-automatically-add-tracksearchbox-when-last-box-is-deleted#diff-193803898fafe6af3bf13214b4e81f2840a3e9b714fdab1d4958c91e9a36e05e)
  checkURL =>syncSelectedTracksWithURL
  
- [react-client/src/layouts/SearchTrackBoxContainer.tsx ](https://github.com/woong8249/trackVStrack/compare/main...13-bug-fix-automatically-add-tracksearchbox-when-last-box-is-deleted#diff-698b711d9f3dfedf57191c00817725024d4eb6635d9063b6ada4d553a779427d)
  - 함수 addSelectBox 제거 
  - 함수changeBoxActivateToTrue 추가
  - deleteSelectBox 함수 id 재할당 로직추가 